### PR TITLE
Fixes to work with current react-native versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 const {
     Dimensions,
     Linking,
-    NetInfo,
     Vibrate,
     Alert,
     AppState
 } = require("react-native");
+const NetInfo = require("@react-native-community/netinfo");
 const localStorage = require('react-native-sync-localstorage');
 
 let currentUrl = '';
@@ -32,7 +32,7 @@ function handleConnectionUpdate(info) {
     netInfo = Object.assign(netInfo, info);
 }
 
-NetInfo.addEventListener('connectionChange', info => {
+NetInfo.addEventListener(info => {
     handleConnectionUpdate(info);
     netInfo.changeListeners.forEach(callback => callback(info));
 });
@@ -40,7 +40,7 @@ NetInfo.addEventListener('connectionChange', info => {
 const promises = [
     localStorage.getAllFromLocalStorage(),
     Linking.getInitialURL().then(url => (url && (currentUrl = url))),
-    NetInfo.getConnectionInfo().then(handleConnectionUpdate)
+    NetInfo.fetch().then(handleConnectionUpdate)
 ];
 
 const allPromises = Promise.all(promises).then(() => {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "react-native-sync-localstorage": "0.0.3"
   },
   "peerDependencies": {
-    "react-native": "^0.54.0 || ^0.60.0 || ^0.61.0"
+    "react-native": "^0.60.0 || ^0.61.0 || ^0.62.0"
   },
   "repository": "https://github.com/ardatan/react-native-browser-polyfills"
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "author": "Arda TANRIKULU",
   "dependencies": {
+    "@react-native-community/netinfo": "5.5.1",
     "react-native-sync-localstorage": "0.0.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
`NetInfo` is no longer in the main `react-native` package and must be imported.